### PR TITLE
Fix/make more rusty

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,57 +14,57 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // find git project root
     let repo = Repository::discover(".")?;
     let repo_path = repo.path().parent().unwrap().to_str().unwrap();
-    let mut default_branch = String::new();
-    let mut owner = String::new();
-    let mut repo_name = String::new();
 
-    // Check if config already defines owner and repo_name
+    // Use match to either load the config from the file or prompt the user
     let config_path = format!("{}/.git/open_pr.toml", repo_path);
-    if std::fs::metadata(&config_path).is_ok() {
-        let config_str = std::fs::read_to_string(&config_path)?;
-        let config: Config = toml::from_str(&config_str)?;
-        owner = config.owner;
-        repo_name = config.repo_name;
-        default_branch = config.default_branch;
-        println!("Owner: {}", owner);
-        println!("Repository Name: {}", repo_name);
-        println!("Default Branch: {}", default_branch);
-        println!("You can tweak this configuration in .git/open_pr.toml");
-    }
-    else {
-        // prompt owner and repo_name
-        println!("Enter the owner of the repository (The \"org\" in github.com/org/reponame): ");
-        std::io::stdin().read_line(&mut owner).unwrap();
-        owner = owner.trim().to_string();
-        println!("Enter the repository name: (The \"reponame\" in github.com/org/reponame): ");
-        std::io::stdin().read_line(&mut repo_name).unwrap();
-        repo_name = repo_name.trim().to_string();
-        println!("Enter the default branch (usually main or master): ");
-        std::io::stdin().read_line(&mut default_branch).unwrap();
-        default_branch = default_branch.trim().to_string();
-        println!("You can tweak this configuration later in .git/open_pr.toml");
-    }
+    let config = match std::fs::read_to_string(&config_path) {
+        Ok(config_str) => {
+            let config: Config = toml::from_str(&config_str)?;
+            println!("Owner: {}", config.owner);
+            println!("Repository Name: {}", config.repo_name);
+            println!("Default Branch: {}", config.default_branch);
+            println!("You can tweak this configuration in .git/open_pr.toml");
+            config
+        }
+        Err(_) => {
+            let mut owner = String::new();
+            let mut repo_name = String::new();
+            let mut default_branch = String::new();
 
-    // Write to .open_pr.toml
-    let config: Config = Config {
-        owner: owner.clone(),
-        repo_name: repo_name.clone(),
-        default_branch: default_branch.clone(),
+            println!("Enter the owner of the repository (The \"org\" in github.com/org/reponame): ");
+            std::io::stdin().read_line(&mut owner).unwrap();
+            println!("Enter the repository name: (The \"reponame\" in github.com/org/reponame): ");
+            std::io::stdin().read_line(&mut repo_name).unwrap();
+            println!("Enter the default branch (usually main or master): ");
+            std::io::stdin().read_line(&mut default_branch).unwrap();
+
+            let config = Config {
+                owner: owner.trim().to_string(),
+                repo_name: repo_name.trim().to_string(),
+                default_branch: default_branch.trim().to_string(),
+            };
+
+            println!("You can tweak this configuration later in .git/open_pr.toml");
+
+            // Write the new configuration to the file
+            let config_str = toml::to_string(&config).unwrap();
+            std::fs::write(&config_path, config_str)?;
+
+            config
+        }
     };
-    let config_str = toml::to_string(&config).unwrap();
-    std::fs::write(format!("{}/.git/open_pr.toml", repo_path), config_str)?;
 
     let repo = Repository::open(".")?;
 
     // Get the current branch
     let head = repo.head()?;
     let head_ref = head.shorthand().unwrap_or("unknown");
-    let base_branch = default_branch;
+    let base_branch = &config.default_branch;
 
     // Build the URL for creating a pull request on GitHub
     let pr_url = format!(
         "https://github.com/{}/{}/compare/{}...{}?expand=1",
-        owner, repo_name, base_branch, head_ref
+        config.owner, config.repo_name, base_branch, head_ref
     );
 
     // Print the URL (optional)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use git2::Repository;
 use open;
 use toml;
@@ -10,6 +11,16 @@ struct Config {
     repo_name: String,
 }
 
+impl fmt::Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Owner: {}\nRepository Name: {}\nDefault Branch: {}",
+            self.owner, self.repo_name, self.default_branch
+        )
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // find git project root
     let repo = Repository::discover(".")?;
@@ -20,9 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = match std::fs::read_to_string(&config_path) {
         Ok(config_str) => {
             let config: Config = toml::from_str(&config_str)?;
-            println!("Owner: {}", config.owner);
-            println!("Repository Name: {}", config.repo_name);
-            println!("Default Branch: {}", config.default_branch);
+            println!("{}", config);
             println!("You can tweak this configuration in .git/open_pr.toml");
             config
         }


### PR DESCRIPTION
moves to slightly more idomatic Rust. Specifically -- rather than doing an `if` against `is_ok()`, we move it to a `match` statement. This allows you to evaluate code and then return exactly the variable you want -- in this case, populating the Config struct -- rather than having to create all the variables first and then try to fill them into the struct later 